### PR TITLE
testConcatRangeMissingCell

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/server/expression/function/SpreadsheetServerExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/expression/function/SpreadsheetServerExpressionFunctionsTest.java
@@ -395,6 +395,16 @@ public final class SpreadsheetServerExpressionFunctionsTest implements PublicSta
         );
     }
 
+
+    @Test
+    public void testConcatRangeMissingCell() {
+        this.evaluateAndValueCheck(
+                "=concat(A2:A5)",
+                Maps.of("A2", "'abc", "A4", "'123"),
+                "abc123"
+        );
+    }
+
     @Test
     public void testConcatSingleValuesAndRange() {
         this.evaluateAndValueCheck(


### PR DESCRIPTION
- closes https://github.com/mP1/walkingkooka-spreadsheet-server-expression-function/issues/24
- Update concat to skip empty cells