### PR TITLE
len(), lower() & upper() unformatted number parameter support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/expression/function/SpreadsheetServerExpressionFunctions.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/expression/function/SpreadsheetServerExpressionFunctions.java
@@ -608,8 +608,10 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
         return LEN;
     }
 
-    private final static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> LEN = StringExpressionFunctions.<SpreadsheetExpressionEvaluationContext>stringLength()
-            .setName(FunctionExpressionName.with("len"));
+    private final static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> LEN = unformattedNumber(
+            StringExpressionFunctions.stringLength(),
+            "len"
+    );
 
     /**
      * {@see NumberExpressionFunctions#ln}
@@ -617,7 +619,7 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
     public static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> ln() {
         return NumberExpressionFunctions.ln();
     }
-    
+
     /**
      * {@see NumberExpressionFunctions#log}
      */
@@ -631,7 +633,7 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
     public static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> log10() {
         return NumberExpressionFunctions.log10();
     }
-    
+
     /**
      * {@see StringExpressionFunctions#lower}
      */
@@ -639,8 +641,10 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
         return LOWER;
     }
 
-    private final static ExpressionFunction<String, SpreadsheetExpressionEvaluationContext> LOWER = StringExpressionFunctions.<SpreadsheetExpressionEvaluationContext>lowerCase()
-            .setName(FunctionExpressionName.with("lower"));
+    private final static ExpressionFunction<String, SpreadsheetExpressionEvaluationContext> LOWER = unformattedNumber(
+            StringExpressionFunctions.lowerCase(),
+            "lower"
+    );
 
     /**
      * {@see StatExpressionFunctions#max}
@@ -648,7 +652,7 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
     public static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> max() {
         return StatExpressionFunctions.max();
     }
-    
+
     /**
      * {@see StringExpressionFunctions#mid}
      */
@@ -1033,8 +1037,10 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
         return UPPER;
     }
 
-    private final static ExpressionFunction<String, SpreadsheetExpressionEvaluationContext> UPPER = StringExpressionFunctions.<SpreadsheetExpressionEvaluationContext>upperCase()
-            .setName(FunctionExpressionName.with("upper"));
+    private final static ExpressionFunction<String, SpreadsheetExpressionEvaluationContext> UPPER = unformattedNumber(
+            StringExpressionFunctions.upperCase(),
+            "upper"
+    );
 
     /**
      * {@see DateTimeExpressionFunctions#weekDay}
@@ -1056,12 +1062,21 @@ public final class SpreadsheetServerExpressionFunctions implements PublicStaticH
     public static ExpressionFunction<ExpressionNumber, SpreadsheetExpressionEvaluationContext> year() {
         return DateTimeExpressionFunctions.year();
     }
-    
+
     /**
      * {@see BooleanExpressionFunctions#xor}
      */
     public static ExpressionFunction<Boolean, SpreadsheetExpressionEvaluationContext> xor() {
         return BooleanExpressionFunctions.xor();
+    }
+
+    private static <T> ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> unformattedNumber(final ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> function,
+                                                                                                       final String name) {
+        return UnformattedNumberExpressionFunction.with(
+                function.setName(
+                        FunctionExpressionName.with(name)
+                )
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/server/expression/function/UnformattedNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/expression/function/UnformattedNumberExpressionFunction.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.server.expression.function;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
+import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
+import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContexts;
+import walkingkooka.tree.expression.ExpressionPurityContext;
+import walkingkooka.tree.expression.FunctionExpressionName;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionKind;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameter;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@link ExpressionFunction} that executes the wraps another {@link ExpressionFunction}, passing a context that
+ * ensures any parameters of type {@link Number} are converted to a {@link String} ignoring the {@link walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName#NUMBER_FORMAT_PATTERN}.
+ */
+final class UnformattedNumberExpressionFunction<T> implements ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> {
+
+    static <T> UnformattedNumberExpressionFunction<T> with(final ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> function) {
+        return new UnformattedNumberExpressionFunction<>(function);
+    }
+
+    private UnformattedNumberExpressionFunction(final ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> function) {
+        super();
+        this.function = function;
+    }
+
+    @Override
+    public FunctionExpressionName name() {
+        return this.function.name();
+    }
+
+    @Override
+    public List<ExpressionFunctionParameter<?>> parameters() {
+        return this.function.parameters();
+    }
+
+    @Override
+    public Class<T> returnType() {
+        return this.function.returnType();
+    }
+
+    @Override
+    public Set<ExpressionFunctionKind> kinds() {
+        return Sets.empty(); // dont want parameters to be prepared in any way.
+    }
+
+    private Set<ExpressionFunctionKind> kinds;
+
+    @Override
+    public T apply(final List<Object> parameters,
+                   final SpreadsheetExpressionEvaluationContext context) {
+        return this.apply0(
+                parameters,
+                SpreadsheetExpressionEvaluationContexts.functionParameterConverter(
+                        SpreadsheetConverters.unformattedNumber().cast(SpreadsheetExpressionEvaluationContext.class),
+                        context
+                )
+        );
+    }
+
+    private T apply0(final List<Object> parameters,
+                     final SpreadsheetExpressionEvaluationContext context) {
+        final ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> function = this.function;
+        return function.apply(
+                context.prepareParameters(
+                        Cast.to(function),
+                        parameters
+                ),
+                context
+        );
+    }
+
+    @Override
+    public boolean isPure(final ExpressionPurityContext context) {
+        return this.function.isPure(context);
+    }
+
+    private final ExpressionFunction<T, SpreadsheetExpressionEvaluationContext> function;
+
+    @Override
+    public String toString() {
+        return this.function.toString();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/server/expression/function/UnformattedNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/expression/function/UnformattedNumberExpressionFunctionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.server.expression.function;
+
+import walkingkooka.Cast;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class UnformattedNumberExpressionFunctionTest implements ClassTesting<UnformattedNumberExpressionFunction<?>> {
+
+    @Override
+    public Class<UnformattedNumberExpressionFunction<?>> type() {
+        return Cast.to(UnformattedNumberExpressionFunction.class);
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-server-expression-function/issues/32
- lower() ignores number formatting when lowering number

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server-expression-function/issues/29
- len() needs to ignore number formatting